### PR TITLE
[Feat] Added get one CVE by id API

### DIFF
--- a/src/cves/cves.controller.ts
+++ b/src/cves/cves.controller.ts
@@ -1,6 +1,6 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query } from '@nestjs/common';
 import { CvesService } from './cves.service';
-import { ApiQuery, ApiTags, ApiOperation } from '@nestjs/swagger';
+import { ApiQuery, ApiTags, ApiOperation, ApiParam } from '@nestjs/swagger';
 
 @ApiTags('cves')
 @Controller('cves')
@@ -77,5 +77,12 @@ export class CvesController {
       sortBy,
       sortOrder,
     );
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Retrieve detailed information for a single CVE' })
+  @ApiParam({ name: 'id', description: 'CVE ID (e.g., CVE-2023-1234)' })
+  async getCveById(@Param('id') id: string) {
+    return this.cvesService.getCveById(id);
   }
 }

--- a/src/cves/cves.service.ts
+++ b/src/cves/cves.service.ts
@@ -275,4 +275,17 @@ export class CvesService {
       data: records,
     };
   }
+
+  async getCveById(id: string) {
+    const query = this.cveRepository
+      .createQueryBuilder('cve')
+      .leftJoinAndSelect('cve.metrics', 'metrics')
+      .leftJoinAndSelect('cve.configurations', 'configurations')
+      .leftJoinAndSelect('cve.weaknesses', 'weaknesses')
+      .leftJoinAndSelect('cve.descriptions', 'descriptions')
+      .leftJoinAndSelect('cve.references', 'references')
+      .where('cve.id = :id', { id });
+
+    return await query.getOne();
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.enableCors();
 
   // Swagger Configuration
   const config = new DocumentBuilder()


### PR DESCRIPTION
### **📌 Summary**
Added API endpoint to fetch a single CVE by its ID and enables CORS support for cross-origin requests.

### **🛠️ Changes**
- **feat: add get CVE by ID API**
  - Implemented a new endpoint: `GET /cves/:id`
  - Allows retrieval of detailed CVE information based on the provided CVE ID.
  - Returns relevant metadata, including CVSS scores and configuration details.

- **feat: enable CORS**
  - Configured Cross-Origin Resource Sharing (CORS) to allow frontend requests.
  - Ensured that requests from different origins (e.g., Next.js frontend) can access the API.

### **🔍 How to Test**
1. **Run the backend server.**
2. **Test the new API endpoint:**
   - Make a request to `GET /cves/{cveId}` using Postman, cURL, or the frontend.
   - Example: `GET /cves/CVE-2025-1234`
   - Expected Response: Detailed CVE data with metrics, scores, and configurations.
3. **Verify CORS functionality:**
   - Make a request from the frontend to confirm cross-origin requests work correctly.
   - Ensure no CORS errors appear in the browser console.

### **✅ Checklist**
- [x] API returns the correct CVE details.
- [x] CORS is properly enabled and tested.
- [x] Endpoint follows RESTful API best practices.